### PR TITLE
Cli update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,14 @@
 ## Availables Docker image tags
 Repository available on Docker Hub: [zenika/terraform-aws-cli](https://hub.docker.com/r/zenika/terraform-aws-cli)
 
-[Debian](https://hub.docker.com/_/debian) based images ([debian.Dockerfile](https://github.com/Zenika/terraform-aws-cli/blob/master/debian.Dockerfile)):
-
-* zenika/terraform-aws-cli:latest-debian - build on master branch
-* zenika/terraform-aws-cli:X.Y-debian - build on repository tags
-
-[Alpine](https://hub.docker.com/_/alpine) based images ([alpine.Dockerfile](https://github.com/Zenika/terraform-aws-cli/blob/master/alpine.Dockerfile)):
-
-* zenika/terraform-aws-cli:latest - build on master branch (default image tag)
-* zenika/terraform-aws-cli:alpine-latest - build on master branch
-* zenika/terraform-aws-cli:X.Y-alpine - build on repository tags
-
-> Git repository tag naming convention: `/^([0-9.]+)$/`
+* [zenika/terraform-aws-cli:latest](https://github.com/Zenika/terraform-aws-cli/blob/master/alpine.Dockerfile)
+* [zenika/terraform-aws-cli:latest-debian](https://github.com/Zenika/terraform-aws-cli/blob/master/debian.Dockerfile)
+* [zenika/terraform-aws-cli:1.0-alpine](https://github.com/Zenika/terraform-aws-cli/blob/1.0/alpine.Dockerfile)
+* [zenika/terraform-aws-cli:1.0-debian](https://github.com/Zenika/terraform-aws-cli/blob/1.0/debian.Dockerfile)
 
 ## Motivation
 
-The goal is to create a **functional**, **minimalist** and **lightweight** image with these tools in order to reduce network and storage impact.
+The goal is to create a **minimalist** and **lightweight** image with these tools in order to reduce network and storage impact.
 
 This image gives you the flexibility to be used for development or as a base image as you see fits.
 

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -1,6 +1,6 @@
 # Setup build arguments with default versions
-ARG AWS_CLI_VERSION=1.16.166
-ARG TERRAFORM_VERSION=0.11.14
+ARG AWS_CLI_VERSION=1.16.177
+ARG TERRAFORM_VERSION=0.12.2
 
 # Download Terraform binary
 FROM alpine:3.9.4 as terraform

--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -1,6 +1,6 @@
 # Setup build arguments with default versions
-ARG AWS_CLI_VERSION=1.16.166
-ARG TERRAFORM_VERSION=0.11.14
+ARG AWS_CLI_VERSION=1.16.177
+ARG TERRAFORM_VERSION=0.12.2
 
 # Download Terraform binary
 FROM debian:stretch-20190506-slim as terraform


### PR DESCRIPTION
* updated TF to 0.12.2
* updated AWS cli to latest minor
* simplified supported tag section in readme (removed `latest-alpine` tag on docker hub, already exist as `latest`tag)