### PR TITLE
updated python, curl and unzip versions to allow for successful build

### DIFF
--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -6,7 +6,7 @@ ARG TERRAFORM_VERSION=0.12.2
 FROM alpine:3.9.4 as terraform
 ARG TERRAFORM_VERSION
 RUN apk update
-RUN apk add curl=7.64.0-r2
+RUN apk add curl=7.64.0-r3
 RUN apk add unzip=6.0-r4
 RUN apk add gnupg=2.2.12-r0
 RUN curl -Os https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS
@@ -22,8 +22,8 @@ RUN unzip -j terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 FROM alpine:3.9.4 as aws-cli
 ARG AWS_CLI_VERSION
 RUN apk update
-RUN apk add python3=3.6.8-r2
-RUN apk add python3-dev=3.6.8-r2
+RUN apk add python3=3.6.9-r2
+RUN apk add python3-dev=3.6.9-r2
 RUN apk add py3-setuptools=40.6.3-r0
 RUN pip3 install awscli==${AWS_CLI_VERSION}
 
@@ -34,7 +34,7 @@ RUN apk --no-cache add \
   ca-certificates=20190108-r0 \
   groff=1.22.3-r2 \
   jq=1.6-r0 \
-  python3=3.6.8-r2 \
+  python3=3.6.9-r2 \
   && ln -s /usr/bin/python3 /usr/bin/python
 COPY --from=terraform /terraform /usr/bin/terraform
 COPY --from=aws-cli /usr/bin/aws* /usr/bin/

--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -7,7 +7,7 @@ FROM debian:stretch-20190506-slim as terraform
 ARG TERRAFORM_VERSION
 RUN apt-get update
 RUN apt-get install -y curl=7.52.1-5+deb9u9
-RUN apt-get install -y unzip=6.0-21+deb9u1
+RUN apt-get install -y unzip=6.0-21+deb9u2
 RUN apt-get install -y gnupg=2.1.18-8~deb9u4
 RUN curl -Os https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS
 RUN curl -Os https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip


### PR DESCRIPTION
Building the image fails with the current defined version of `unzip=6.0-21+deb9u1`. This version has been replaced with the latest version.

```
Step 7/30 : RUN apt-get install -y unzip=6.0-21+deb9u1
 ---> Running in cde028776d69
Reading package lists...
Building dependency tree...
Reading state information...
E: Version '6.0-21+deb9u1' for 'unzip' was not found
The command '/bin/sh -c apt-get install -y unzip=6.0-21+deb9u1' returned a non-zero code: 100
```